### PR TITLE
Added the ability to fetch enabled dates by the delegate, week by week

### DIFF
--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.h
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.h
@@ -7,6 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "DailyCalendarView.h"
+
 @protocol CLWeeklyCalendarViewDelegate <NSObject>
 
 // Keys for customize the calendar behavior
@@ -17,6 +19,7 @@ extern NSString *const CLCalendarFutureDayNumberTextColor;  //Day number text co
 extern NSString *const CLCalendarCurrentDayNumberTextColor; //Day number text color for today
 extern NSString *const CLCalendarSelectedDayNumberTextColor;    //Day number text color for the selected day
 extern NSString *const CLCalendarSelectedCurrentDayNumberTextColor; //Day number text color when today is selected
+extern NSString *const CLCalendarDotTextColor; //The color of the dot indicating an enabled date
 extern NSString *const CLCalendarCurrentDayNumberBackgroundColor;   //Day number background color for today when not selected
 extern NSString *const CLCalendarSelectedDayNumberBackgroundColor;  //Day number background color for selected day
 extern NSString *const CLCalendarSelectedCurrentDayNumberBackgroundColor;   //Day number background color when today is selected
@@ -32,6 +35,17 @@ extern NSString *const CLCalendarFont; //Preferred font of the calendar UI, defa
 
 @optional
 - (NSDictionary *)CLCalendarBehaviorAttributes;       //Optional Function, Set the calendar behavior attributes by using above keys
+/**
+ *  Informs the weekly view which dates in a week span are enabled. These will be requested as you swipe through the weeks.
+ *
+ *  @param initialDate the first day of the given week
+ *  @param finalDate   the last date of the given week
+ 
+ *  @discussion The dictionary does not need to be exaustive, i.e., the simple absence of a date means it is disabled
+ *
+ *  @return the resulting dictionary, with dates as keys and boolean NSNumbers as values.
+ */
+- (NSDictionary<NSDate*, NSNumber*>*)enabledDatesFromDate:(NSDate*)initialDate toDate:(NSDate*)finalDate;
 
 @end
 
@@ -41,7 +55,16 @@ extern NSString *const CLCalendarFont; //Preferred font of the calendar UI, defa
 @property (nonatomic, strong) NSDate *selectedDate;
 @property (nonatomic, strong) NSDictionary *calendarAttributes;
 
-@property (nonatomic, strong) NSArray *enabledDates; //Array of dates you want to enable (the rest of the dates will be disabled). Disabled dates will not be tappable.
+/**
+ *  Array of dates you want to enable. Their behavior will depend on enabledDatesAppearance and disabledDatesInteractionEnabled
+ */
+@property (nonatomic, strong) NSArray *enabledDates;
+/**
+ *  Wether enabled dates will have different backgrounds (default) or show dots below them
+ */
+@property (nonatomic) CLEnabledDatesAppearance enabledDatesAppearance;
+@property (nonatomic) BOOL disabledDatesInteractionEnabled;
+
 
 - (void)redrawToDate: (NSDate *)dt;
 - (void)updateWeatherIconByKey: (NSString *)key;

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/CLWeeklyCalendarView.m
@@ -39,6 +39,7 @@ NSString *const CLCalendarFutureDayNumberTextColor = @"CLCalendarFutureDayNumber
 NSString *const CLCalendarCurrentDayNumberTextColor = @"CLCalendarCurrentDayNumberTextColor";
 NSString *const CLCalendarSelectedDayNumberTextColor = @"CLCalendarSelectedDayNumberTextColor";
 NSString *const CLCalendarSelectedCurrentDayNumberTextColor = @"CLCalendarSelectedCurrentDayNumberTextColor";
+NSString *const CLCalendarDotTextColor = @"CLCalendarDotTextColor";
 NSString *const CLCalendarCurrentDayNumberBackgroundColor = @"CLCalendarCurrentDayNumberBackgroundColor";
 NSString *const CLCalendarSelectedDayNumberBackgroundColor = @"CLCalendarSelectedDayNumberBackgroundColor";
 NSString *const CLCalendarSelectedCurrentDayNumberBackgroundColor = @"CLCalendarSelectedCurrentDayNumberBackgroundColor";
@@ -60,6 +61,7 @@ static NSInteger const CLCalendarFutureDayNumberTextColorDefault = 0xFFFFFF;
 static NSInteger const CLCalendarCurrentDayNumberTextColorDefault = 0xFFFFFF;
 static NSInteger const CLCalendarSelectedDayNumberTextColorDefault = 0x34A1FF;
 static NSInteger const CLCalendarSelectedCurrentDayNumberTextColorDefault = 0x0081c1;
+static NSInteger const CLCalendarDotTextColorDefault = 0xffffff;
 static NSInteger const CLCalendarCurrentDayNumberBackgroundColorDefault = 0x0081c1;
 static NSInteger const CLCalendarSelectedDayNumberBackgroundColorDefault = 0xffffff;
 static NSInteger const CLCalendarSelectedCurrentDayNumberBackgroundColorDefault = 0xffffff;
@@ -89,6 +91,7 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
 @property (nonatomic, strong) UIColor *currentDayNumberTextColor;
 @property (nonatomic, strong) UIColor *selectedDayNumberTextColor;
 @property (nonatomic, strong) UIColor *selectedCurrentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *dotTextColor;
 @property (nonatomic, strong) UIColor *currentDayNumberBackgroundColor;
 @property (nonatomic, strong) UIColor *selectedDayNumberBackgroundColor;
 @property (nonatomic, strong) UIColor *selectedCurrentDayNumberBackgroundColor;
@@ -101,6 +104,8 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
 @property (nonatomic, strong) UIColor *backgroundImageColor;
 
 @property (nonatomic, strong) UIFont *calendarFont;
+
+@property (nonatomic, strong) NSDictionary<NSDate*, NSNumber*>* currentWeekEnabledDates;
 
 @end
 
@@ -170,37 +175,39 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
         attributes = self.calendarAttributes;
     }
     
-    self.weekStartConfig = attributes[CLCalendarWeekStartDay] ? attributes[CLCalendarWeekStartDay] : [NSNumber numberWithInt:CLCalendarWeekStartDayDefault];
+    self.weekStartConfig = attributes[CLCalendarWeekStartDay] ?: [NSNumber numberWithInt:CLCalendarWeekStartDayDefault];
     
-    self.dayTitleTextColor = attributes[CLCalendarDayTitleTextColor]? attributes[CLCalendarDayTitleTextColor]:[UIColor colorWithHex:CLCalendarDayTitleTextColorDefault];
+    self.dayTitleTextColor = attributes[CLCalendarDayTitleTextColor] ?: [UIColor colorWithHex:CLCalendarDayTitleTextColorDefault];
     
-    self.pastDayNumberTextColor = attributes[CLCalendarPastDayNumberTextColor] ? attributes[CLCalendarPastDayNumberTextColor] : [UIColor colorWithHex:CLCalendarPastDayNumberTextColorDefault];
+    self.pastDayNumberTextColor = attributes[CLCalendarPastDayNumberTextColor] ?: [UIColor colorWithHex:CLCalendarPastDayNumberTextColorDefault];
     
-    self.futureDayNumberTextColor = attributes[CLCalendarFutureDayNumberTextColor] ? attributes[CLCalendarFutureDayNumberTextColor] : [UIColor colorWithHex:CLCalendarFutureDayNumberTextColorDefault];
+    self.futureDayNumberTextColor = attributes[CLCalendarFutureDayNumberTextColor] ?: [UIColor colorWithHex:CLCalendarFutureDayNumberTextColorDefault];
 
-    self.currentDayNumberTextColor = attributes[CLCalendarCurrentDayNumberTextColor] ? attributes[CLCalendarCurrentDayNumberTextColor] : [UIColor colorWithHex:CLCalendarCurrentDayNumberTextColorDefault];
+    self.currentDayNumberTextColor = attributes[CLCalendarCurrentDayNumberTextColor] ?: [UIColor colorWithHex:CLCalendarCurrentDayNumberTextColorDefault];
     
-    self.selectedDayNumberTextColor = attributes[CLCalendarSelectedDayNumberTextColor] ? attributes[CLCalendarSelectedDayNumberTextColor] : [UIColor colorWithHex:CLCalendarSelectedDayNumberTextColorDefault];
+    self.selectedDayNumberTextColor = attributes[CLCalendarSelectedDayNumberTextColor] ?: [UIColor colorWithHex:CLCalendarSelectedDayNumberTextColorDefault];
     
-    self.selectedCurrentDayNumberTextColor = attributes[CLCalendarSelectedCurrentDayNumberTextColor] ? attributes[CLCalendarSelectedCurrentDayNumberTextColor] : [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberTextColorDefault];
+    self.selectedCurrentDayNumberTextColor = attributes[CLCalendarSelectedCurrentDayNumberTextColor] ?: [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberTextColorDefault];
     
-    self.currentDayNumberBackgroundColor = attributes[CLCalendarCurrentDayNumberBackgroundColor] ? attributes[CLCalendarCurrentDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarCurrentDayNumberBackgroundColorDefault];
+    self.dotTextColor = attributes[CLCalendarDotTextColor] ?: [UIColor colorWithHex:CLCalendarDotTextColor];
     
-    self.selectedDayNumberBackgroundColor = attributes[CLCalendarSelectedDayNumberBackgroundColor] ? attributes[CLCalendarSelectedDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarSelectedDayNumberBackgroundColorDefault];
+    self.currentDayNumberBackgroundColor = attributes[CLCalendarCurrentDayNumberBackgroundColor] ?: [UIColor colorWithHex:CLCalendarCurrentDayNumberBackgroundColorDefault];
     
-    self.selectedCurrentDayNumberBackgroundColor = attributes[CLCalendarSelectedCurrentDayNumberBackgroundColor] ? attributes[CLCalendarSelectedCurrentDayNumberBackgroundColor] : [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberBackgroundColorDefault];
+    self.selectedDayNumberBackgroundColor = attributes[CLCalendarSelectedDayNumberBackgroundColor] ?: [UIColor colorWithHex:CLCalendarSelectedDayNumberBackgroundColorDefault];
     
-    self.selectedDatePrintFormat = attributes[CLCalendarSelectedDatePrintFormat]? attributes[CLCalendarSelectedDatePrintFormat] : CLCalendarSelectedDatePrintFormatDefault;
+    self.selectedCurrentDayNumberBackgroundColor = attributes[CLCalendarSelectedCurrentDayNumberBackgroundColor] ?: [UIColor colorWithHex:CLCalendarSelectedCurrentDayNumberBackgroundColorDefault];
     
-    self.selectedDatePrintColor = attributes[CLCalendarSelectedDatePrintColor]? attributes[CLCalendarSelectedDatePrintColor] : [UIColor whiteColor];
+    self.selectedDatePrintFormat = attributes[CLCalendarSelectedDatePrintFormat] ?: CLCalendarSelectedDatePrintFormatDefault;
     
-    self.selectedDatePrintFontSize = attributes[CLCalendarSelectedDatePrintFontSize]? [attributes[CLCalendarSelectedDatePrintFontSize] floatValue] : CLCalendarSelectedDatePrintFontSizeDefault;
+    self.selectedDatePrintColor = attributes[CLCalendarSelectedDatePrintColor] ?: [UIColor whiteColor];
     
-    self.disabledDateBackgroundColor = attributes[CLCalendarDisabledDayBackgroundColor] ? attributes[CLCalendarDisabledDayBackgroundColor] : [UIColor colorWithHex:CLCalendarDisabledDayBackgroundColorDefault];
+    self.selectedDatePrintFontSize = attributes[CLCalendarSelectedDatePrintFontSize] ? [attributes[CLCalendarSelectedDatePrintFontSize] floatValue] : CLCalendarSelectedDatePrintFontSizeDefault;
     
-    self.disabledDateTextColor = attributes[CLCalendarDisabledDayTextColor] ? attributes[CLCalendarDisabledDayTextColor] : [UIColor colorWithHex:CLCalendarDisabledDayTextColorDefault];
+    self.disabledDateBackgroundColor = attributes[CLCalendarDisabledDayBackgroundColor] ?: [UIColor colorWithHex:CLCalendarDisabledDayBackgroundColorDefault];
     
-    self.calendarFont = attributes[CLCalendarFont] ? attributes[CLCalendarFont] : [UIFont systemFontOfSize:10.0f];
+    self.disabledDateTextColor = attributes[CLCalendarDisabledDayTextColor] ?: [UIColor colorWithHex:CLCalendarDisabledDayTextColorDefault];
+    
+    self.calendarFont = attributes[CLCalendarFont] ?: [UIFont systemFontOfSize:10.0f];
     
     self.backgroundImageColor = attributes[CLCalendarBackgroundImageColor];
     
@@ -305,6 +312,8 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
     NSDate *today = [NSDate new];
     NSDate *dtWeekStart = [today getWeekStartDate:self.weekStartConfig.integerValue];
     self.startDate = dtWeekStart;
+    self.endDate = [dtWeekStart addDays:WEEKLY_VIEW_COUNT - 1];
+    
     
     for (UIView *v in [self.dailySubViewContainer subviews]) {
         [v removeFromSuperview];
@@ -313,14 +322,16 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
         [v removeFromSuperview];
     }
     
+    if ([self.delegate respondsToSelector:@selector(enabledDatesFromDate:toDate:)]) {
+        self.currentWeekEnabledDates = [self.delegate enabledDatesFromDate:self.startDate toDate:self.endDate];
+    }
+    
     for(int i = 0; i < WEEKLY_VIEW_COUNT; i++){
         NSDate *dt = [dtWeekStart addDays:i];
         
         [self dayTitleViewForDate: dt inFrame: CGRectMake(dailyWidth*i, 0, dailyWidth, DAY_TITLE_VIEW_HEIGHT)];
         
         [self dailyViewForDate:dt inFrame: CGRectMake(dailyWidth*i, 0, dailyWidth, DATE_VIEW_HEIGHT) ];
-        
-        self.endDate = dt;
     }
     
     [self dailyCalendarViewDidSelect:[NSDate new]];
@@ -359,6 +370,7 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
     view.futureDayNumberTextColor = self.futureDayNumberTextColor;
     view.currentDayNumberTextColor = self.currentDayNumberTextColor;
     view.selectedCurrentDayNumberTextColor = self.selectedCurrentDayNumberTextColor;
+    view.dotTextColor = self.dotTextColor;
     
     //Background colors
     view.selectedDayNumberTextColor = self.selectedDayNumberTextColor;
@@ -375,6 +387,9 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
     
     view.dateEnabled = [self isDateEnabled:date];
     
+    view.disabledDatesInteractionEnabled = self.disabledDatesInteractionEnabled;
+    view.enabledDatesAppearance = self.enabledDatesAppearance;
+    
     [self.dailySubViewContainer addSubview:view];
     
     return view;
@@ -382,19 +397,12 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
 
 -(void)markDateSelected:(NSDate *)date
 {
-    
+    if (!self.disabledDatesInteractionEnabled && ![self isDateEnabled:date]) {
+        return;
+    }
+ 
     for (DailyCalendarView *v in [self.dailySubViewContainer subviews]) {
         [v markSelected:([v.date isSameDateWith:date])];
-    }
-    
-    //If not enabled, do not mark it as selected and do not do anything
-    if ([self isDateEnabled:date] == NO) {
-        
-        for (DailyCalendarView *v in [self.dailySubViewContainer subviews]) {
-            [v markSelected:([v.date isSameDateWith:self.selectedDate])];
-        }
-        
-        return;
     }
     
     self.selectedDate = date;
@@ -503,8 +511,14 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
     }
     
     self.startDate = dtStart;
+    self.endDate = [dtStart addDays:WEEKLY_VIEW_COUNT - 1];
+    
     for (UIView *v in [self.dailySubViewContainer subviews]){
         [v removeFromSuperview];
+    }
+    
+    if ([self.delegate respondsToSelector:@selector(enabledDatesFromDate:toDate:)]) {
+        self.currentWeekEnabledDates = [self.delegate enabledDatesFromDate:self.startDate toDate:self.endDate];
     }
     
     for(int i = 0; i < WEEKLY_VIEW_COUNT; i++){
@@ -515,7 +529,6 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
         titleLabel.date = dt;
         
         [view markSelected:([view.date isSameDateWith:self.selectedDate])];
-        self.endDate = dt;
     }
 }
 
@@ -537,7 +550,7 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
     [self markDateSelected:date];
     
     //If not enabled, do not call the delegate method.
-    if ([self isDateEnabled:date] == NO) {
+    if (!self.disabledDatesInteractionEnabled && [self isDateEnabled:date] == NO) {
         return;
     }
     
@@ -562,6 +575,9 @@ static NSInteger const CLCalendarBackgroundDefaultColor = 0xaaaaaa;
         }];
         
         return enabled;
+    }
+    else if (self.currentWeekEnabledDates) {
+        return self.currentWeekEnabledDates[date].boolValue;
     }
     
     return YES;

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.h
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.h
@@ -7,6 +7,19 @@
 //
 
 #import <UIKit/UIKit.h>
+
+/**
+ Changes the enabled dates appearance in the calendar view.
+ @see CLEnabledDatesAppearanceBackground
+ @see CLEnabledDatesAppearanceDot
+ */
+typedef enum : NSUInteger {
+    /** Changes background colors between enabled and disabled dates */
+    CLEnabledDatesAppearanceBackground,
+    /** Adds a dot below enabled dates */
+    CLEnabledDatesAppearanceDot,
+} CLEnabledDatesAppearance;
+
 @protocol DailyCalendarViewDelegate <NSObject>
 
 -(void)dailyCalendarViewDidSelect: (NSDate *)date;
@@ -20,12 +33,15 @@
 @property (nonatomic) BOOL blnSelected;
 
 @property (nonatomic) BOOL dateEnabled;
+@property (nonatomic) BOOL disabledDatesInteractionEnabled;
+@property (nonatomic) CLEnabledDatesAppearance enabledDatesAppearance;
 
 @property (nonatomic, strong) UIColor *pastDayNumberTextColor;
 @property (nonatomic, strong) UIColor *futureDayNumberTextColor;
 @property (nonatomic, strong) UIColor *currentDayNumberTextColor;
 @property (nonatomic, strong) UIColor *selectedDayNumberTextColor;
 @property (nonatomic, strong) UIColor *selectedCurrentDayNumberTextColor;
+@property (nonatomic, strong) UIColor *dotTextColor;
 @property (nonatomic, strong) UIColor *currentDayNumberBackgroundColor;
 @property (nonatomic, strong) UIColor *selectedDayNumberBackgroundColor;
 @property (nonatomic, strong) UIColor *selectedCurrentDayNumberBackgroundColor;

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/DailyCalendarView.m
@@ -13,6 +13,7 @@
 
 @property (nonatomic, strong) UILabel *dateLabel;
 @property (nonatomic, strong) UIView *dateLabelContainer;
+@property (nonatomic, strong) UILabel *dotLabel;
 
 @end
 
@@ -27,6 +28,7 @@
     if (self) {
         // Initialization code
         [self addSubview:self.dateLabelContainer];
+        [self addSubview:self.dotLabel];
         
         UITapGestureRecognizer *singleFingerTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(dailyViewDidClick:)];
         [self addGestureRecognizer:singleFingerTap];
@@ -61,6 +63,26 @@
     return _dateLabel;
 }
 
+-(UILabel *)dotLabel {
+    
+    if(!_dotLabel) {
+        _dotLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, DATE_LABEL_SIZE/2, self.bounds.size.width, 20)];
+        _dotLabel.backgroundColor = [UIColor clearColor];
+        _dotLabel.textColor = [UIColor whiteColor];
+        _dotLabel.textAlignment = NSTextAlignmentCenter;
+        _dotLabel.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:30];
+        _dotLabel.text = @".";
+        _dotLabel.hidden = YES;
+    }
+    
+    return _dotLabel;
+}
+
+-(void)didMoveToSuperview {
+    self.dotLabel.textColor = self.dotTextColor;
+}
+
+
 -(void)setDate:(NSDate *)date {
     
     _date = date;
@@ -92,8 +114,14 @@
     }
     
     if (self.dateEnabled == NO) {
-        self.dateLabel.textColor = self.disabledDayTextColor;
-        self.dateLabel.backgroundColor = self.disabledDayBackgroundColor;
+        if (self.enabledDatesAppearance == CLEnabledDatesAppearanceBackground) {
+            self.dateLabel.textColor = self.disabledDayTextColor;
+            self.dateLabel.backgroundColor = self.disabledDayBackgroundColor;
+        }
+        self.dotLabel.hidden = YES;
+    }
+    else if (self.enabledDatesAppearance == CLEnabledDatesAppearanceDot) {
+        self.dotLabel.hidden = NO;
     }
 }
 

--- a/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/Misc/NSDate+CL.m
+++ b/CLWeeklyCalendarView/CLWeeklyCalendarViewSourceCode/Misc/NSDate+CL.m
@@ -42,8 +42,8 @@
     static NSDateFormatter *shortDayOfWeekFormatter;
     if(!shortDayOfWeekFormatter){
         shortDayOfWeekFormatter = [[NSDateFormatter alloc] init];
-        NSLocale* en_AU_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_AU_POSIX"];
-        [shortDayOfWeekFormatter setLocale:en_AU_POSIX];
+//        NSLocale* en_AU_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_AU_POSIX"];
+//        [shortDayOfWeekFormatter setLocale:en_AU_POSIX];
         [shortDayOfWeekFormatter setDateFormat:@"E"];
     }
     return [shortDayOfWeekFormatter stringFromDate:self];
@@ -54,8 +54,8 @@
     static NSDateFormatter *dateFormaater;
     if(!dateFormaater){
         dateFormaater = [[NSDateFormatter alloc] init];
-        NSLocale* en_AU_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_AU_POSIX"];
-        [dateFormaater setLocale:en_AU_POSIX];
+//        NSLocale* en_AU_POSIX = [[NSLocale alloc] initWithLocaleIdentifier:@"en_AU_POSIX"];
+//        [dateFormaater setLocale:en_AU_POSIX];
         [dateFormaater setDateFormat:@"d"];
     }
     return [dateFormaater stringFromDate:self];


### PR DESCRIPTION
Hi! Thanks for the work maintaining this component!
I needed a few features and thought you might want to merge with the library.
The most important change I made is that now the enabled dates can be served by the delegate instead of with the property. My usage would have to take a huge penalty to decide wether the dates had data so early. Instead, I only grab one week at a time of data, as needed. The old way is still there, the one you use will be picked up by the library.
Also, I added an option to show dots below enabled dates instead of changing the background of the disabled ones - this is an enum (CLEnabledDatesAppearanceBackground, default, same as old component , CLEnabledDatesAppearanceDot, new behavior), and color configurable with CLDotTextColor dictionary attribute.
You can also make the disabled dates have userInteraction if desired.
